### PR TITLE
Add api key auth middleware + static api key in setting

### DIFF
--- a/Wiinf-Studie.API/Middlewares/ApiKeyAuthorizationMiddleware.cs
+++ b/Wiinf-Studie.API/Middlewares/ApiKeyAuthorizationMiddleware.cs
@@ -1,0 +1,30 @@
+namespace Wiinf_Studie.API.Middlewares;
+
+public class ApiKeyAuthorizationMiddleware
+{
+    private readonly RequestDelegate _next;
+    private const string APIKEY = "XApiKey";
+    public ApiKeyAuthorizationMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Headers.TryGetValue(APIKEY, out
+                var extractedApiKey))
+        {
+            context.Response.StatusCode = 401;
+            await context.Response.WriteAsync("Api Key was not provided ");
+            return;
+        }
+        var appSettings = context.RequestServices.GetRequiredService<IConfiguration>();
+        var apiKey = appSettings.GetValue<string>(APIKEY);
+        if (!apiKey.Equals(extractedApiKey))
+        {
+            context.Response.StatusCode = 401;
+            await context.Response.WriteAsync("Unauthorized client");
+            return;
+        }
+        await _next(context);
+    }
+}

--- a/Wiinf-Studie.API/Program.cs
+++ b/Wiinf-Studie.API/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Wiinf_Studie.API.Data;
 using Wiinf_Studie.API.Data.Migrations;
+using Wiinf_Studie.API.Middlewares;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -26,9 +27,10 @@ app.UseSwaggerUI(options =>
     options.RoutePrefix = string.Empty;
 });
 
-// app.UseHttpsRedirection();
+// app.UseHttpsRedirection(); // Disabled for testing purposes
 
-// app.UseAuthorization();
+// Add authorization via API keys
+app.UseMiddleware<ApiKeyAuthorizationMiddleware>();
 
 app.MapControllers();
 

--- a/Wiinf-Studie.API/appsettings.Development.json
+++ b/Wiinf-Studie.API/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "XApiKey": "pgH7QzFHJx4w46fI~5Uzi4RvtTwlEXp"
 }


### PR DESCRIPTION
Todo: https://github.com/IanBuck-dev/wiinf-studie-ms-sap-integration/issues/9

Adds simple middleware to add api key authorization. The api key is currently simply stored inside the settings (unsafe) for testing purposes.

Can be used by adding Header with key: XApiKey and the value see development settings file