### PR TITLE
Add simple pagination using LIMIT

### DIFF
--- a/Wiinf-Studie.API/Controllers/DoublePaymentsController.cs
+++ b/Wiinf-Studie.API/Controllers/DoublePaymentsController.cs
@@ -32,6 +32,8 @@ public class DoublePaymentsController : ControllerBase
 
         var result = await _candidatesRepository.GetDoublePaymentPairsIncludingCandidates(requestContext);
 
+        HttpContext.AddPagedContextInfo(requestContext);
+
         return Ok(result);
     }
 

--- a/Wiinf-Studie.API/Controllers/DoublePaymentsController.cs
+++ b/Wiinf-Studie.API/Controllers/DoublePaymentsController.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Wiinf_Studie.API.Data;
 using Wiinf_Studie.API.Models;
+using Wiinf_Studie.API.Utils;
 
 namespace Wiinf_Studie.API.Controllers;
 
@@ -27,8 +28,9 @@ public class DoublePaymentsController : ControllerBase
     [ProducesResponseType(typeof(IEnumerable<DoublePaymentPair>), (int)HttpStatusCode.OK)]
     public async Task<IActionResult> Get()
     {
-        // Todo: Add paging
-        var result = await _candidatesRepository.GetDoublePaymentPairsIncludingCandidates();
+        var requestContext = HttpContext.GetRequestContext();
+
+        var result = await _candidatesRepository.GetDoublePaymentPairsIncludingCandidates(requestContext);
 
         return Ok(result);
     }

--- a/Wiinf-Studie.API/Data/CandidatesRepository.cs
+++ b/Wiinf-Studie.API/Data/CandidatesRepository.cs
@@ -49,13 +49,13 @@ namespace Wiinf_Studie.API.Data
         /// </summary>
         public async Task<IEnumerable<DoublePaymentPair>> GetDoublePaymentPairsIncludingCandidates(RequestContext requestContext)
         {
-            var parameters = new { Page = requestContext.Page * requestContext.PageSize, PageSize = requestContext.PageSize };
+            var parameters = new { Page = (requestContext.Page - 1) * requestContext.PageSize, PageSize = requestContext.PageSize };
             var sql = @"select *
                 from DoublePaymentPairs p
                 Left Join DoublePaymentCandidates c1 on p.Candidate1Id = c1.CandidateId
                 left join DoublePaymentCandidates c2 on p.Candidate2Id = c2.CandidateId
                 ORDER BY PairId
-                LIMIT @PageSize, @Page";
+                LIMIT @Page, @PageSize";
 
             var result = await _dbConnection.QueryAsync<DoublePaymentPair, DoublePaymentCandidate, DoublePaymentCandidate, DoublePaymentPair>(sql, (pair, candidate1, candidate2) =>
             {

--- a/Wiinf-Studie.API/Data/CandidatesRepository.cs
+++ b/Wiinf-Studie.API/Data/CandidatesRepository.cs
@@ -54,6 +54,7 @@ namespace Wiinf_Studie.API.Data
                 from DoublePaymentPairs p
                 Left Join DoublePaymentCandidates c1 on p.Candidate1Id = c1.CandidateId
                 left join DoublePaymentCandidates c2 on p.Candidate2Id = c2.CandidateId
+                ORDER BY PairId
                 LIMIT @PageSize, @Page";
 
             var result = await _dbConnection.QueryAsync<DoublePaymentPair, DoublePaymentCandidate, DoublePaymentCandidate, DoublePaymentPair>(sql, (pair, candidate1, candidate2) =>

--- a/Wiinf-Studie.API/Data/CandidatesRepository.cs
+++ b/Wiinf-Studie.API/Data/CandidatesRepository.cs
@@ -47,12 +47,14 @@ namespace Wiinf_Studie.API.Data
         /// <summary>
         /// Returns all double payment pair including both candidates.
         /// </summary>
-        public async Task<IEnumerable<DoublePaymentPair>> GetDoublePaymentPairsIncludingCandidates()
+        public async Task<IEnumerable<DoublePaymentPair>> GetDoublePaymentPairsIncludingCandidates(RequestContext requestContext)
         {
+            var parameters = new { Page = requestContext.Page * requestContext.PageSize, PageSize = requestContext.PageSize };
             var sql = @"select *
                 from DoublePaymentPairs p
                 Left Join DoublePaymentCandidates c1 on p.Candidate1Id = c1.CandidateId
-                left join DoublePaymentCandidates c2 on p.Candidate2Id = c2.CandidateId";
+                left join DoublePaymentCandidates c2 on p.Candidate2Id = c2.CandidateId
+                LIMIT @PageSize, @Page";
 
             var result = await _dbConnection.QueryAsync<DoublePaymentPair, DoublePaymentCandidate, DoublePaymentCandidate, DoublePaymentPair>(sql, (pair, candidate1, candidate2) =>
             {
@@ -61,6 +63,7 @@ namespace Wiinf_Studie.API.Data
 
                 return pair;
             },
+            param: parameters,
             splitOn: "CandidateId");
 
             return result;

--- a/Wiinf-Studie.API/Models/DoublePaymentPair.cs
+++ b/Wiinf-Studie.API/Models/DoublePaymentPair.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Wiinf_Studie.API.Models;
 
 public class DoublePaymentPair

--- a/Wiinf-Studie.API/Models/RequestContext.cs
+++ b/Wiinf-Studie.API/Models/RequestContext.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Wiinf_Studie.API.Models;
+
+public class RequestContext
+{
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 1000;
+    public string? FilterBy { get; set; }
+    public string? OrderBy { get; set; }
+}

--- a/Wiinf-Studie.API/Program.cs
+++ b/Wiinf-Studie.API/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Data.Sqlite;
 using Wiinf_Studie.API.Data;
 using Wiinf_Studie.API.Data.Migrations;
 using Wiinf_Studie.API.Middlewares;
+using Wiinf_Studie.API.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -44,7 +45,7 @@ using (var scope = app.Services.CreateScope())
 {
     var repo = scope.ServiceProvider.GetService<CandidatesRepository>();
 
-    if (!(await repo.GetDoublePaymentPairsIncludingCandidates()).Any())
+    if (!(await repo.GetDoublePaymentPairsIncludingCandidates(new RequestContext())).Any())
     {
         // If no entries yet, seed database.
         await DatabaseSetup.SeedDatabaseWithDummyData(100);

--- a/Wiinf-Studie.API/Utils/HttpContextUtils.cs
+++ b/Wiinf-Studie.API/Utils/HttpContextUtils.cs
@@ -4,8 +4,8 @@ namespace Wiinf_Studie.API.Utils;
 
 public static class HttpContextUtils
 {
-    public const string PageHeaderKey = "page";
-    public const string PageSizeHeaderKey = "pageSize";
+    public const string PageQueryKey = "page";
+    public const string PageSizeQueryKey = "pageSize";
 
     /// <summary>
     /// Gets the page, pageSize, orderby and filterby from the current http context.
@@ -20,7 +20,7 @@ public static class HttpContextUtils
         // Get and validate page number (1 or more).
         var pageNumber = 1;
 
-        if (httpContext.Request.Headers.TryGetValue(PageHeaderKey, out var pageHeader))
+        if (httpContext.Request.Query.TryGetValue(PageQueryKey, out var pageHeader))
         {
             if (int.TryParse(pageHeader, out var parsedPage) && parsedPage >= 1)
             {
@@ -29,9 +29,9 @@ public static class HttpContextUtils
         }
 
         // Get and validate page size (1 - 1000 items).
-        var pageSize = 1;
+        var pageSize = 1000;
 
-        if (httpContext.Request.Headers.TryGetValue(PageSizeHeaderKey, out var pageSizeHeader))
+        if (httpContext.Request.Query.TryGetValue(PageSizeQueryKey, out var pageSizeHeader))
         {
             if (int.TryParse(pageSizeHeader, out var parsedPageSize) && parsedPageSize >= 1 && parsedPageSize <= 1000)
             {
@@ -52,5 +52,17 @@ public static class HttpContextUtils
         };
 
         return requestContext;
+    }
+
+    /// <summary>
+    /// Adds the pagination info onto the 
+    /// </summary>
+    /// <param name="httpContext"></param>
+    /// <param name="context"></param>
+    public static void AddPagedContextInfo(this HttpContext httpContext, RequestContext context)
+    {
+        httpContext.Response.Headers.TryAdd("page", context.Page.ToString());
+        httpContext.Response.Headers.TryAdd("pageSize", context.PageSize.ToString());
+        // Todo: add total items count if needed.
     }
 }

--- a/Wiinf-Studie.API/Utils/HttpContextUtils.cs
+++ b/Wiinf-Studie.API/Utils/HttpContextUtils.cs
@@ -1,0 +1,56 @@
+using Wiinf_Studie.API.Models;
+
+namespace Wiinf_Studie.API.Utils;
+
+public static class HttpContextUtils
+{
+    public const string PageHeaderKey = "page";
+    public const string PageSizeHeaderKey = "pageSize";
+
+    /// <summary>
+    /// Gets the page, pageSize, orderby and filterby from the current http context.
+    /// Todo: Check if PowerApps supports such custom headers and query string contents.
+    /// https://learn.microsoft.com/en-us/connectors/custom-connectors/policy-templates/setheader/setheader
+    /// </summary>
+    /// <param name="httpContext">The current http context.</param>
+    public static RequestContext GetRequestContext(this HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        // Get and validate page number (1 or more).
+        var pageNumber = 1;
+
+        if (httpContext.Request.Headers.TryGetValue(PageHeaderKey, out var pageHeader))
+        {
+            if (int.TryParse(pageHeader, out var parsedPage) && parsedPage >= 1)
+            {
+                pageNumber = parsedPage;
+            }
+        }
+
+        // Get and validate page size (1 - 1000 items).
+        var pageSize = 1;
+
+        if (httpContext.Request.Headers.TryGetValue(PageSizeHeaderKey, out var pageSizeHeader))
+        {
+            if (int.TryParse(pageSizeHeader, out var parsedPageSize) && parsedPageSize >= 1 && parsedPageSize <= 1000)
+            {
+                pageSize = parsedPageSize;
+            }
+        }
+
+        // Get query string contents (default pairId ascending)
+        // Todo: Implement FilterBy and OrderBy
+        var orderBy = "PairId asc";
+
+        var requestContext = new RequestContext()
+        {
+            Page = pageNumber,
+            PageSize = pageSize,
+            OrderBy = orderBy,
+            FilterBy = null,
+        };
+
+        return requestContext;
+    }
+}


### PR DESCRIPTION
Gets page number and page size from header values with default to 1 and 1000.
Implemented with LIMIT SQL parameter. This is not the most efficient, as SQLIte reads all skipped values anyways: https://stackoverflow.com/questions/14468586/efficient-paging-in-sqlite-with-millions-of-records
-> cursor based pagination would be better in this case (but prob harder to implement in PowerApps)